### PR TITLE
Add support for Accumulo

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,7 @@ def install_dependent_roles
 end
 
 # Install missing role dependencies based on the contents of roles.txt
-if [ "up", "provision" ].include?(ARGV.first)
+if [ "up", "provision", "status" ].include?(ARGV.first)
   install_dependent_roles
 end
 
@@ -70,11 +70,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     exit(1)
   end
 
+  if Vagrant.has_plugin?("vagrant-cachier") &&
+    VAGRANT_PROXYCONF_ENDPOINT.nil?
+    config.cache.scope = :box
+  end
+
   config.vm.define "leader" do |leader|
     leader.hostmanager.aliases = [
       "zookeeper.service.geotrellis-spark.internal",
       "namenode.service.geotrellis-spark.internal",
-      "mesos-leader.service.geotrellis-spark.internal"
+      "mesos-leader.service.geotrellis-spark.internal",
+      "accumulo-leader.service.geotrellis-spark.internal"
     ]
 
     leader.vm.hostname = "leader"
@@ -88,6 +94,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     leader.vm.network "forwarded_port", guest: 8080, host: 8080
     # HDFS console
     leader.vm.network "forwarded_port", guest: 50070, host: 50070
+    # Accumulo console
+    leader.vm.network "forwarded_port", guest: 50095, host: 50095
 
     leader.vm.provider "virtualbox" do |v|
       v.memory = 3072

--- a/deployment/ansible/follower.yml
+++ b/deployment/ansible/follower.yml
@@ -8,5 +8,6 @@
 
   roles:
     - { role: "geotrellis-spark-cluster.common" }
-    - { role: "azavea.hdfs", hdfs_namenode: False }
+    - { role: "geotrellis-spark-cluster.hdfs", hdfs_namenode: False }
     - { role: "geotrellis-spark-cluster.mesos", mesos_leader: False }
+    - { role: "geotrellis-spark-cluster.accumulo", accumulo_leader: False }

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,12 +1,15 @@
 ---
 mesos_follower: not mesos_leader
+accumulo_follower: not accumulo_leader
 developing: "'development' in group_names"
 packing: "'packer' in group_names"
 
 java_version: "7u71-2.5.3-0ubuntu0.14.04.1"
-spark_version: "1.1.0+cdh5.2.1+63-1.cdh5.2.1.p0.9~trusty-cdh5.2.1"
-hdfs_version: "2.5.0+cdh5.2.1+578-1.cdh5.2.1.p0.14~trusty-cdh5.2.1"
-zookeeper_version: "3.4.5+cdh5.2.1+84-1.cdh5.2.1.p0.13~trusty-cdh5.2.1"
+spark_version: "1.2.0+cdh5.3.0+364-1.cdh5.3.0.p0.36~trusty-cdh5.3.0"
+hdfs_version: "2.5.0+cdh5.3.0+781-1.cdh5.3.0.p0.54~trusty-cdh5.3.0"
+zookeeper_version: "3.4.5+cdh5.3.0+81-1.cdh5.3.0.p0.36~trusty-cdh5.3.0"
+mesos_version: "0.21.1-1.1.ubuntu1404"
+marathon_version: "0.7.6-1.0"
 
 zookeeper_servers:
   - { index: "0", ip: "zookeeper.service.geotrellis-spark.internal", ports: "2888:3888" }
@@ -16,3 +19,16 @@ mesos_leader_hostname: "mesos-leader.service.geotrellis-spark.internal"
 mesos_leader_quorum: 1
 
 hdfs_namenode_host: "namenode.service.geotrellis-spark.internal"
+hdfs_core_properties:
+  - { name: "fs.defaultFS", value: "hdfs://{{ hdfs_namenode_host }}:{{ hdfs_namenode_port }}" }
+hdfs_namenode_properties:
+  - { name: "dfs.permissions.superusergroup", value: "hadoop" }
+  - { name: "dfs.namenode.name.dir", value: "/media/persistent0" }
+hdfs_datanode_properties:
+  - { name: "dfs.permissions.superusergroup", value: "hadoop" }
+  - { name: "dfs.datanode.data.dir", value: "{{ hdfs_disks | map(attribute='mount_point') | join(',') }}" }
+  - { name: "dfs.datanode.synconclose", value: "true" }
+
+accumulo_leader_host: "accumulo-leader.service.geotrellis-spark.internal"
+accumulo_instance_name: "geotrellis-accumulo-cluster"
+accumulo_secret: "secret"

--- a/deployment/ansible/inventory/development
+++ b/deployment/ansible/inventory/development
@@ -1,6 +1,6 @@
-leader ansible_ssh_host=33.33.33.10
-follower01 ansible_ssh_host=33.33.33.20
-follower02 ansible_ssh_host=33.33.33.30
+leader ansible_ssh_host=33.33.33.10 ansible_ssh_user=vagrant
+follower01 ansible_ssh_host=33.33.33.20 ansible_ssh_user=vagrant
+follower02 ansible_ssh_host=33.33.33.30 ansible_ssh_user=vagrant
 
 [leaders]
 leader

--- a/deployment/ansible/leader.yml
+++ b/deployment/ansible/leader.yml
@@ -10,12 +10,14 @@
       lineinfile: dest="/etc/hosts"
                   regexp="^127.0.1.1"
                   line="127.0.1.1 {{ leader_hostnames }}"
+                  state=present
       when: packing
 
   roles:
     - { role: "geotrellis-spark-cluster.common" }
     - { role: "azavea.hdfs", hdfs_namenode: True }
     - { role: "geotrellis-spark-cluster.mesos", mesos_leader: True }
+    - { role: "geotrellis-spark-cluster.accumulo", accumulo_leader: True }
 
   post_tasks:
     - meta: flush_handlers
@@ -24,4 +26,5 @@
       lineinfile: dest="/etc/hosts"
                   regexp="^127.0.1.1"
                   line=""
+                  state=absent
       when: packing

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -1,8 +1,10 @@
+azavea.build-essential,0.1.0
 azavea.ntp,0.1.0
 azavea.java,0.1.0
 azavea.zookeeper,0.2.0
 azavea.mesos,0.2.0
 azavea.marathon,0.2.0
-azavea.hdfs,0.2.1
+azavea.hdfs,0.3.0
 azavea.libgdal-java,0.1.0
-azavea.spark,0.1.0
+azavea.spark,0.1.1
+azavea.accumulo,0.1.0

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/default/main.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/default/main.yml
@@ -1,0 +1,3 @@
+---
+accumulo_instance_name: "default"
+accumulo_secret: "DEFAULT"

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/meta/main.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.accumulo" }

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/tasks/configure_accumulo_follower.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/tasks/configure_accumulo_follower.yml
@@ -1,0 +1,15 @@
+---
+- name: Create cron script to initialize Accumulo follower
+  template: src=accumulo-follower-cron.j2
+            dest=/usr/local/bin/accumulo-follower-cron
+            owner=root
+            group=root
+            mode=0755
+
+- name: Create cron job to initialize Accumulo follower
+  cron: name="accumulo-follower"
+        minute="*/1"
+        user="root"
+        job="/usr/local/bin/accumulo-follower-cron >> /var/log/accumulo-follower-cron.log 2>&1"
+        cron_file="accumulo-follower"
+        state=present

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/tasks/configure_accumulo_leader.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/tasks/configure_accumulo_leader.yml
@@ -1,0 +1,15 @@
+---
+- name: Create cron script to initialize Accumulo leader
+  template: src=accumulo-leader-cron.j2
+            dest=/usr/local/bin/accumulo-leader-cron
+            owner=root
+            group=root
+            mode=0755
+
+- name: Create cron job to initialize Accumulo leader
+  cron: name="accumulo-leader"
+        minute="*/1"
+        user="root"
+        job="/usr/local/bin/accumulo-leader-cron >> /var/log/accumulo-leader-cron.log 2>&1"
+        cron_file="accumulo-leader"
+        state=present

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/tasks/main.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: Add Accumulo user to HDFS supergroup
+  user: name=accumulo
+        append=yes
+        group=hadoop
+        state=present
+
+- name: Create service definition overrides
+  copy: content="manual"
+        dest=/etc/init/accumulo-{{ item }}.override
+        mode=0644
+  with_items:
+    - gc
+    - master
+    - monitor
+    - tracer
+    - tserver
+
+- name: Configure Accumulo
+  template: src={{ item }}.j2
+            dest={{ accumulo_conf_dir }}/{{ item }}
+            owner=accumulo
+            group=root
+            mode=0644
+  with_items:
+    - accumulo-env.sh
+    - accumulo-metrics.xml
+    - accumulo-site.xml
+    - generic_logger.xml
+    - log4j.properties
+    - monitor_logger.xml
+
+- name: Set master for Accumulo followers
+  copy: content="{{ accumulo_leader_host }}"
+        dest="{{ accumulo_conf_dir }}/masters"
+        mode=0644
+
+- { include: configure_accumulo_leader.yml, when: accumulo_leader }
+- { include: configure_accumulo_follower.yml, when: accumulo_follower }
+

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-env.sh.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-env.sh.j2
@@ -1,0 +1,57 @@
+#! /usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###
+### Configure these environment variables to point to your local installations.
+###
+### The functional tests require conditional values, so keep this style:
+###
+### test -z "$JAVA_HOME" && export JAVA_HOME=/usr/local/lib/jdk-1.6.0
+###
+###
+### Note that the -Xmx -Xms settings below require substantial free memory:
+### you may want to use smaller values, especially when running everything
+### on a single machine.
+###
+
+if [ -z "$HADOOP_HOME" ]
+then
+   test -z "$HADOOP_PREFIX"      && export HADOOP_PREFIX=/usr/lib/hadoop
+else
+   HADOOP_PREFIX="$HADOOP_HOME"
+   unset HADOOP_HOME
+fi
+
+test -z "$HADOOP_CONF_DIR"       && export HADOOP_CONF_DIR="/etc/hadoop/conf"
+test -z "$JAVA_HOME"             && export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
+test -z "$ZOOKEEPER_HOME"        && export ZOOKEEPER_HOME=/usr/lib/zookeeper
+test -z "$ACCUMULO_LOG_DIR"      && export ACCUMULO_LOG_DIR=$ACCUMULO_HOME/logs
+if [ -f ${ACCUMULO_CONF_DIR}/accumulo.policy ]
+then
+   POLICY="-Djava.security.manager -Djava.security.policy=${ACCUMULO_CONF_DIR}/accumulo.policy"
+fi
+test -z "$ACCUMULO_TSERVER_OPTS" && export ACCUMULO_TSERVER_OPTS="${POLICY} -Xmx1g -Xms1g -XX:NewSize=500m -XX:MaxNewSize=500m "
+test -z "$ACCUMULO_MASTER_OPTS"  && export ACCUMULO_MASTER_OPTS="${POLICY} -Xmx1g -Xms1g"
+test -z "$ACCUMULO_MONITOR_OPTS" && export ACCUMULO_MONITOR_OPTS="${POLICY} -Xmx1g -Xms256m"
+test -z "$ACCUMULO_GC_OPTS"      && export ACCUMULO_GC_OPTS="-Xmx256m -Xms256m"
+test -z "$ACCUMULO_GENERAL_OPTS" && export ACCUMULO_GENERAL_OPTS="-XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -Djava.net.preferIPv4Stack=true"
+test -z "$ACCUMULO_OTHER_OPTS"   && export ACCUMULO_OTHER_OPTS="-Xmx1g -Xms256m"
+# what do when the JVM runs out of heap memory
+export ACCUMULO_KILL_CMD='kill -9 %p'
+
+# Should the monitor bind to all network interfaces -- default: false
+export ACCUMULO_MONITOR_BIND_ALL="true"

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-follower-cron.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-follower-cron.j2
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if hdfs dfs -test -d /accumulo; then
+  # Accumulo has been initialized; remove service definition overrides
+  rm -f /etc/init/accumulo-tserver.override
+
+  # Start Accumulo services
+  /sbin/start accumulo-tserver
+
+  # Shoot self in head
+  rm /etc/cron.d/accumulo-follower
+fi

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-leader-cron.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-leader-cron.j2
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if sudo -E -u hdfs hdfs dfsadmin -report -live | egrep "Live datanodes \([^0][0-9]?\)"; then
+  # Live datanodes exist; has Accumulo been initialized?
+  if ! hdfs dfs -test -d /accumulo; then
+    sudo -E -u accumulo accumulo init \
+      --instance-name {{ accumulo_secret }} \
+      --password {{ accumulo_secret }}
+
+    # Remove service definition overrides
+    rm -f \
+      /etc/init/accumulo-gc.override \
+      /etc/init/accumulo-master.override \
+      /etc/init/accumulo-monitor.override \
+      /etc/init/accumulo-tracer.override
+
+    # Start Accumulo services
+    /sbin/start accumulo-master
+    /sbin/start accumulo-monitor
+    /sbin/start accumulo-gc
+    /sbin/start accumulo-tracer
+
+    # Shoot self in head
+    rm /etc/cron.d/accumulo-leader
+  fi
+fi

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-metrics.xml.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-metrics.xml.j2
@@ -1,0 +1,56 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  This file follows the conventions for XMLConfiguration files specified in the Apache Commons Configuration 1.5 Library. Changes to this file will be noticed
+  at runtime (see the FileChangedReloadingStrategy class in Commons Configuration).
+-->
+<config>
+<!--
+   Metrics log directory
+-->
+  <logging>
+    <dir>${ACCUMULO_HOME}/metrics</dir>
+  </logging>
+<!--
+ Enable/Disable metrics accumulation on the different servers and their components
+ NOTE: Turning on logging can be expensive because it will use several more file handles and will create a lot of short lived objects.
+-->
+  <master>
+    <enabled type="boolean">false</enabled>
+    <logging type="boolean">false</logging>
+  </master>
+  <tserver>
+    <enabled type="boolean">false</enabled>
+    <logging type="boolean">false</logging>
+    <update>
+      <enabled type="boolean">false</enabled>
+      <logging type="boolean">false</logging>
+    </update>
+    <scan>
+      <enabled type="boolean">false</enabled>
+      <logging type="boolean">false</logging>
+    </scan>
+    <minc>
+      <enabled type="boolean">false</enabled>
+      <logging type="boolean">false</logging>
+    </minc>
+  </tserver>
+  <thrift>
+    <enabled type="boolean">false</enabled>
+    <logging type="boolean">false</logging>
+  </thrift>
+</config>

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-site.xml.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-site.xml.j2
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <!-- Put your site-specific accumulo configurations here. The available configuration values along with their defaults are documented in docs/config.html Unless
+    you are simply testing at your workstation, you will most definitely need to change the three entries below. -->
+
+  <property>
+    <name>instance.zookeeper.host</name>
+    <value>{{ zookeeper_servers | map(attribute="ip") | join(":2181,") }}</value>
+    <description>comma separated list of zookeeper servers</description>
+  </property>
+
+  <property>
+    <name>logger.dir.walog</name>
+    <value>walogs</value>
+    <description>The property only needs to be set if upgrading from 1.4 which used to store write-ahead logs on the local
+      filesystem. In 1.5 write-ahead logs are stored in DFS.  When 1.5 is started for the first time it will copy any 1.4
+      write ahead logs into DFS.  It is possible to specify a comma-separated list of directories.
+    </description>
+  </property>
+
+  <property>
+    <name>instance.secret</name>
+    <value>{{ accumulo_secret }}</value>
+    <description>A secret unique to a given instance that all servers must know in order to communicate with one another.
+      Change it before initialization. To
+      change it later use ./bin/accumulo org.apache.accumulo.server.util.ChangeSecret --old [oldpasswd] --new [newpasswd],
+      and then update this file.
+    </description>
+  </property>
+
+  <property>
+    <name>tserver.memory.maps.max</name>
+    <value>1G</value>
+  </property>
+
+  <property>
+    <name>tserver.cache.data.size</name>
+    <value>128M</value>
+  </property>
+
+  <property>
+    <name>tserver.cache.index.size</name>
+    <value>128M</value>
+  </property>
+
+  <property>
+    <name>trace.token.property.password</name>
+    <!-- change this to the root user's password, and/or change the user below -->
+    <value>secret</value>
+  </property>
+
+  <property>
+    <name>trace.user</name>
+    <value>root</value>
+  </property>
+
+  <property>
+    <name>general.classpaths</name>
+    <value>
+      $ACCUMULO_HOME/server/target/classes/,
+      $ACCUMULO_HOME/lib/accumulo-server.jar,
+      $ACCUMULO_HOME/core/target/classes/,
+      $ACCUMULO_HOME/lib/accumulo-core.jar,
+      $ACCUMULO_HOME/start/target/classes/,
+      $ACCUMULO_HOME/lib/accumulo-start.jar,
+      $ACCUMULO_HOME/fate/target/classes/,
+      $ACCUMULO_HOME/lib/accumulo-fate.jar,
+      $ACCUMULO_HOME/proxy/target/classes/,
+      $ACCUMULO_HOME/lib/accumulo-proxy.jar,
+      $ACCUMULO_HOME/lib/[^.].*.jar,
+      $ZOOKEEPER_HOME/zookeeper[^.].*.jar,
+      $HADOOP_CONF_DIR,
+      $HADOOP_PREFIX/[^.].*.jar,
+      $HADOOP_PREFIX/lib/[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/common/.*.jar,
+      $HADOOP_PREFIX/share/hadoop/common/lib/.*.jar,
+      $HADOOP_PREFIX/share/hadoop/hdfs/.*.jar,
+      $HADOOP_PREFIX/share/hadoop/mapreduce/.*.jar,
+      $HADOOP_PREFIX/share/hadoop/yarn/.*.jar,
+      /usr/lib/hadoop/.*.jar,
+      /usr/lib/hadoop/lib/.*.jar,
+      /usr/lib/hadoop-hdfs/.*.jar,
+      /usr/lib/hadoop-mapreduce/.*.jar,
+      /usr/lib/hadoop-yarn/.*.jar,
+    </value>
+    <description>Classpaths that accumulo checks for updates and class files.
+      When using the Security Manager, please remove the ".../target/classes/" values.
+    </description>
+  </property>
+</configuration>

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/generic_logger.xml.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/generic_logger.xml.j2
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+  <!-- Write out everything at the DEBUG level to the debug log -->
+  <appender name="A2" class="org.apache.log4j.RollingFileAppender">
+     <param name="File"           value="${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${org.apache.accumulo.core.ip.localhost.hostname}.debug.log"/>
+     <param name="MaxFileSize"    value="1000MB"/>
+     <param name="MaxBackupIndex" value="10"/>
+     <param name="Threshold"      value="DEBUG"/>
+     <layout class="org.apache.log4j.PatternLayout">
+       <param name="ConversionPattern" value="%d{ISO8601} [%-8c{2}] %-5p: %m%n"/>
+     </layout>
+  </appender>
+
+  <!--  Write out INFO and higher to the regular log -->
+  <appender name="A3" class="org.apache.log4j.RollingFileAppender">
+     <param name="File"           value="${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${org.apache.accumulo.core.ip.localhost.hostname}.log"/>
+     <param name="MaxFileSize"    value="1000MB"/>
+     <param name="MaxBackupIndex" value="10"/>
+     <param name="Threshold"      value="INFO"/>
+     <layout class="org.apache.log4j.PatternLayout">
+       <param name="ConversionPattern" value="%d{ISO8601} [%-8c{2}] %-5p: %m%n"/>
+     </layout>
+  </appender>
+
+  <!-- Send all logging data to a centralized logger -->
+  <appender name="N1" class="org.apache.log4j.net.SocketAppender">
+     <param name="remoteHost"     value="${org.apache.accumulo.core.host.log}"/>
+     <param name="port"           value="${org.apache.accumulo.core.host.log.port}"/>
+     <param name="application"    value="${org.apache.accumulo.core.application}:${org.apache.accumulo.core.ip.localhost.hostname}"/>
+     <param name="Threshold"      value="WARN"/>
+  </appender>
+
+  <!--  If the centralized logger is down, buffer the log events, but drop them if it stays down -->
+  <appender name="ASYNC" class="org.apache.log4j.AsyncAppender">
+     <appender-ref ref="N1" />
+  </appender>
+
+  <!-- Log accumulo events to the debug, normal and remote logs. -->
+  <logger name="org.apache.accumulo" additivity="false">
+     <level value="DEBUG"/>
+     <appender-ref ref="A2" />
+     <appender-ref ref="A3" />
+     <appender-ref ref="ASYNC" />
+  </logger>
+
+  <logger name="org.apache.accumulo.server.security.Auditor">
+     <level value="WARN"/> <!-- change to INFO for authorization events -->
+  </logger>
+
+  <logger name="org.apache.accumulo.core.file.rfile.bcfile">
+     <level value="INFO"/>
+  </logger>
+
+  <logger name="org.mortbay.log">
+     <level value="WARN"/>
+  </logger>
+
+  <logger name="com.yahoo.zookeeper">
+     <level value="ERROR"/>
+  </logger>
+
+  <!-- Log non-accumulo events to the debug and normal logs. -->
+  <root>
+     <level value="INFO"/>
+     <appender-ref ref="A2" />
+     <appender-ref ref="A3" />
+  </root>
+
+</log4j:configuration>

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/log4j.properties.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/log4j.properties.j2
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# default logging properties:
+#  by default, log everything at INFO or higher to the console
+log4j.rootLogger=INFO,A1
+
+# hide Jetty junk
+log4j.logger.org.mortbay.log=WARN,A1
+
+# hide "Got brand-new compresssor" messages
+log4j.logger.org.apache.hadoop.io.compress=WARN,A1
+
+# hide junk from TestRandomDeletes
+log4j.logger.org.apache.accumulo.test.TestRandomDeletes=WARN,A1
+
+# hide junk from VFS
+log4j.logger.org.apache.commons.vfs2.impl.DefaultFileSystemManager=WARN,A1
+
+# hide almost everything from zookeeper
+log4j.logger.org.apache.zookeeper=ERROR,A1
+
+# hide AUDIT messages in the shell, alternatively you could send them to a different logger
+log4j.logger.org.apache.accumulo.core.util.shell.Shell.audit=WARN,A1
+
+# Send most things to the console
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout.ConversionPattern=%d{ISO8601} [%-8c{2}] %-5p: %m%n
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/monitor_logger.xml.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/monitor_logger.xml.j2
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+  <!-- Write out everything at the DEBUG level to the debug log -->
+  <appender name="A2" class="org.apache.log4j.RollingFileAppender">
+     <param name="File"           value="${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${org.apache.accumulo.core.ip.localhost.hostname}.debug.log"/>
+     <param name="MaxFileSize"    value="100MB"/>
+     <param name="MaxBackupIndex" value="10"/>
+     <param name="Threshold"      value="DEBUG"/>
+     <layout class="org.apache.log4j.PatternLayout">
+       <param name="ConversionPattern" value="%d{ISO8601} [%-8c{2}] %-5p: %X{application} %m%n"/>
+     </layout>
+  </appender>
+
+  <!--  Write out INFO and higher to the regular log -->
+  <appender name="A3" class="org.apache.log4j.RollingFileAppender">
+     <param name="File"           value="${org.apache.accumulo.core.dir.log}/${org.apache.accumulo.core.application}_${org.apache.accumulo.core.ip.localhost.hostname}.log"/>
+     <param name="MaxFileSize"    value="100MB"/>
+     <param name="MaxBackupIndex" value="10"/>
+     <param name="Threshold"      value="INFO"/>
+     <layout class="org.apache.log4j.PatternLayout">
+       <param name="ConversionPattern" value="%d{ISO8601} [%-8c{2}] %-5p: %X{application} %m%n"/>
+     </layout>
+  </appender>
+
+  <!-- Keep the last few log messages for display to the user -->
+  <appender name="GUI" class="org.apache.accumulo.server.monitor.LogService">
+     <param name="keep"           value="40"/>
+     <param name="Threshold"      value="WARN"/>
+  </appender>
+
+  <!-- Log accumulo messages to debug, normal and GUI -->
+  <logger name="org.apache.accumulo" additivity="false">
+     <level value="DEBUG"/>
+     <appender-ref ref="A2" />
+     <appender-ref ref="A3" />
+     <appender-ref ref="GUI" />
+  </logger>
+
+  <!-- Log non-accumulo messages to debug, normal logs. -->
+  <root>
+     <level value="INFO"/>
+     <appender-ref ref="A2" />
+     <appender-ref ref="A3" />
+  </root>
+
+</log4j:configuration>

--- a/deployment/ansible/roles/geotrellis-spark-cluster.common/handlers/main.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.common/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Update sysctl
+  command: sysctl -e -p /etc/sysctl.d/10-swappiness.conf

--- a/deployment/ansible/roles/geotrellis-spark-cluster.common/tasks/main.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.common/tasks/main.yml
@@ -3,6 +3,7 @@
   lineinfile: dest="/etc/hosts"
               regexp="^127.0.1.1"
               line=""
+              state=absent
   when: developing
 
 - name: Increase ulimits
@@ -12,3 +13,10 @@
   with_items:
     - soft
     - hard
+
+- name: Set system swappiness
+  copy: content="vm.swappiness = 0"
+        dest=/etc/sysctl.d/10-swappiness.conf
+        mode=0644
+  notify:
+    - Update sysctl

--- a/deployment/ansible/roles/geotrellis-spark-cluster.hdfs/meta/main.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.hdfs/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: "azavea.hdfs" }

--- a/deployment/ansible/roles/geotrellis-spark-cluster.hdfs/tasks/main.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.hdfs/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Add Vagrant user to HDFS supergroup
+  user: name=vagrant
+        append=yes
+        group=hadoop
+        state=present
+  when: developing
+
+- name: Add Ubuntu user to HDFS supergroup
+  user: name=ubuntu
+        append=yes
+        group=hadoop
+        state=present
+  when: packing


### PR DESCRIPTION
This changeset is kinda hacky, but seems like the quickest way to support Accumulo in Vagrant and AWS (with AMIs).

Leaders have a cron job wired up that runs every minute. That job waits for the HDFS NameNode to report greater than zero DataNodes. Once that occurs, it initializes Accumulo within HDFS and starts the required services.

Followers have a different cron job that also runs every minute. That job waits for Accumulo to be initialized by looking for the `/accumulo` directory within HDFS. Once that directory exists, the Accumulo Tablet Server service is initialized.
