### PR TITLE
Add support for r3 and i2 instance types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 deployment/troposphere/*.json
 deployment/ansible/roles/*
 !deployment/ansible/roles/geotrellis-spark-cluster.*
+
+*.pem

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -9,13 +9,16 @@ build:
 clean:
 	@rm troposphere/*.json
 
-vpc-stack:
+vpc-stack: build
 	./deployment-helper.sh create-vpc-stack
 
-leader-stack:
+private-hosted-zones:
+	./deployment-helper.sh create-private-hosted-zones
+
+leader-stack: build
 	./deployment-helper.sh create-leader-stack
 
-follower-stack:
+follower-stack: build
 	./deployment-helper.sh create-follower-stack
 
 leader-ami:

--- a/deployment/ansible/group_vars/packer
+++ b/deployment/ansible/group_vars/packer
@@ -7,5 +7,6 @@ ntp_servers:
 
 hdfs_disks:
   - { device: "/dev/xvdb", mount_point: "/media/ephemeral0" }
+  - { device: "/dev/xvdc", mount_point: "/media/ephemeral1" }
 
-leader_hostnames: "{{ zookeeper_servers[0].ip }} {{ mesos_leader_hostname }} {{ hdfs_namenode_host }}"
+leader_hostnames: "{{ zookeeper_servers[0].ip }} {{ mesos_leader_hostname }} {{ hdfs_namenode_host }} {{ accumulo_leader_host }}"

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-leader-cron.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-leader-cron.j2
@@ -4,26 +4,24 @@ set -e
 set -x
 
 if sudo -E -u hdfs hdfs dfsadmin -report -live | egrep "Live datanodes \([^0][0-9]?\)"; then
-  # Live datanodes exist; has Accumulo been initialized?
-  if ! hdfs dfs -test -d /accumulo; then
-    sudo -E -u accumulo accumulo init \
-      --instance-name {{ accumulo_secret }} \
-      --password {{ accumulo_secret }}
+  # Live datanodes exist
+  sudo -E -u accumulo accumulo init \
+    --instance-name {{ accumulo_secret }} \
+    --password {{ accumulo_secret }}
 
-    # Remove service definition overrides
-    rm -f \
-      /etc/init/accumulo-gc.override \
-      /etc/init/accumulo-master.override \
-      /etc/init/accumulo-monitor.override \
-      /etc/init/accumulo-tracer.override
+  # Remove service definition overrides
+  rm -f \
+    /etc/init/accumulo-gc.override \
+    /etc/init/accumulo-master.override \
+    /etc/init/accumulo-monitor.override \
+    /etc/init/accumulo-tracer.override
 
-    # Start Accumulo services
-    /sbin/start accumulo-master
-    /sbin/start accumulo-monitor
-    /sbin/start accumulo-gc
-    /sbin/start accumulo-tracer
+  # Start Accumulo services
+  /sbin/start accumulo-master
+  /sbin/start accumulo-monitor
+  /sbin/start accumulo-gc
+  /sbin/start accumulo-tracer
 
-    # Shoot self in head
-    rm /etc/cron.d/accumulo-leader
-  fi
+  # Shoot self in head
+  rm /etc/cron.d/accumulo-leader
 fi

--- a/deployment/ansible/roles/geotrellis-spark-cluster.common/tasks/main.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.common/tasks/main.yml
@@ -15,7 +15,7 @@
     - hard
 
 - name: Set system swappiness
-  copy: content="vm.swappiness = 0"
+  copy: content="vm.swappiness=0"
         dest=/etc/sysctl.d/10-swappiness.conf
         mode=0644
   notify:

--- a/deployment/cloud-config/follower.yml
+++ b/deployment/cloud-config/follower.yml
@@ -1,10 +1,29 @@
 #cloud-config
 
+fs_setup:
+   - label: ephemeral0,
+     filesystem: ext3
+     extra_opts: [ "-E", "nodiscard" ]
+     device: ephemeral0
+     partition: auto
+   - label: ephemeral1,
+     filesystem: ext3
+     extra_opts: [ "-E", "nodiscard" ]
+     device: ephemeral1
+     partition: auto
+
 mounts:
  - [ ephemeral0, null ]
- - [ ephemeral0, "/media/ephemeral0" ]
+ - [ ephemeral1, null ]
+ - [ ephemeral0, "/media/ephemeral0", "ext3", "defaults,nobootwait,discard", "0", "2" ]
+ - [ ephemeral1, "/media/ephemeral1", "ext3", "defaults,nobootwait,discard", "0", "2" ]
 
 bootcmd:
- - [ wget, "--quiet", "--output-document", "/etc/mesos-slave/hostname", "http://169.254.169.254/latest/meta-data/public-hostname" ]
+ - [ wget, "--quiet", "--output-document", "/etc/mesos-slave/hostname", "http://instance-data.ec2.internal/latest/meta-data/public-hostname" ]
+
+runcmd:
  - [ chown, hdfs, "/media/ephemeral0" ]
  - [ chgrp, hdfs, "/media/ephemeral0" ]
+ - [ chown, hdfs, "/media/ephemeral1" ]
+ - [ chgrp, hdfs, "/media/ephemeral1" ]
+ - [ service, hadoop-hdfs-datanode, restart ]

--- a/deployment/cloud-config/leader.yml
+++ b/deployment/cloud-config/leader.yml
@@ -1,4 +1,4 @@
 #cloud-config
 
 bootcmd:
- - [ wget, "--quiet", "--output-document", "/etc/mesos-master/hostname", "http://169.254.169.254/latest/meta-data/public-hostname" ]
+ - [ wget, "--quiet", "--output-document", "/etc/mesos-master/hostname", "http://instance-data.ec2.internal/latest/meta-data/public-hostname" ]

--- a/deployment/cloud-config/packer.yml
+++ b/deployment/cloud-config/packer.yml
@@ -1,5 +1,19 @@
 #cloud-config
 
+fs_setup:
+   - label: ephemeral0,
+     filesystem: ext3
+     extra_opts: [ "-E", "nodiscard" ]
+     device: ephemeral0
+     partition: auto
+   - label: ephemeral1,
+     filesystem: ext3
+     extra_opts: [ "-E", "nodiscard" ]
+     device: ephemeral1
+     partition: auto
+
 mounts:
  - [ ephemeral0, null ]
- - [ ephemeral0, "/media/ephemeral0" ]
+ - [ ephemeral1, null ]
+ - [ ephemeral0, "/media/ephemeral0", "ext3", "defaults,nobootwait,discard", "0", "2" ]
+ - [ ephemeral1, "/media/ephemeral1", "ext3", "defaults,nobootwait,discard", "0", "2" ]

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -1,13 +1,10 @@
 {
   "variables": {
     "aws_region": "us-east-1",
-    "aws_instance_type": "m3.medium",
     "aws_ssh_username": "ubuntu",
     "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-    "aws_ubuntu_ami": "",
-    "aws_vpc_id": "",
-    "aws_subnet": ""
+    "aws_ubuntu_ami": ""
   },
   "builders": [
     {
@@ -17,14 +14,12 @@
       "secret_key": "{{user `aws_secret_key` }}",
       "region": "{{user `aws_region`}}",
       "source_ami": "{{user `aws_ubuntu_ami`}}",
-      "instance_type": "{{user `aws_instance_type`}}",
+      "instance_type": "r3.large",
       "ssh_username": "{{user `aws_ssh_username`}}",
       "ami_name": "mesos-leader-{{timestamp}}",
       "tags": {
         "name": "mesos-leader"
       },
-      "vpc_id": "{{user `aws_vpc_id`}}",
-      "subnet_id": "{{user `aws_subnet`}}",
       "associate_public_ip_address": true
     },
     {
@@ -34,21 +29,23 @@
       "secret_key": "{{user `aws_secret_key` }}",
       "region": "{{user `aws_region`}}",
       "source_ami": "{{user `aws_ubuntu_ami`}}",
-      "instance_type": "{{user `aws_instance_type`}}",
+      "instance_type": "i2.2xlarge",
       "ssh_username": "{{user `aws_ssh_username`}}",
       "ami_name": "mesos-follower-{{timestamp}}",
       "ami_block_device_mappings": [
         {
-          "device_name": "/dev/sdb",
+          "device_name": "/dev/xvdb",
           "virtual_name": "ephemeral0"
+        },
+        {
+          "device_name": "/dev/xvdc",
+          "virtual_name": "ephemeral1"
         }
       ],
       "user_data_file": "cloud-config/packer.yml",
       "tags": {
         "name": "mesos-follower"
       },
-      "vpc_id": "{{user `aws_vpc_id`}}",
-      "subnet_id": "{{user `aws_subnet`}}",
       "associate_public_ip_address": true
     }
   ],

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,3 +1,4 @@
-awscli==1.6.5
-troposphere==0.6.2
+awscli==1.6.10
 boto==2.34.0
+requests==2.4.1
+troposphere==0.6.2

--- a/deployment/troposphere/template_utils.py
+++ b/deployment/troposphere/template_utils.py
@@ -1,7 +1,5 @@
 import boto
 
-from troposphere import Ref, Tags, ec2
-
 VPC_CIDR = '10.0.0.0/16'
 ALLOW_ALL_CIDR = '0.0.0.0/0'
 
@@ -24,84 +22,6 @@ def read_file(file_name):
     """
     with open(file_name, 'r') as f:
         return f.read()
-
-
-def create_route_table(template, name, vpc, **attrs):
-    """Creates a route table as part of an existing VPC
-
-    Arguments
-    :param template: An instance of troposphere.Template
-    :param name: A name for the route table
-    :param vpc: An instance of troposphere.ec2.VPC
-    :param **attrs: Additional arguments for troposphere.ec2.RouteTable
-    """
-    return template.add_resource(ec2.RouteTable(
-        name,
-        VpcId=Ref(vpc),
-        Tags=Tags(Name=name),
-        **attrs
-    ))
-
-
-def create_subnet(template, name, vpc, cidr_block, availability_zone):
-    """Creates a subnet as part of an existing VPC
-
-    Arguments
-    :param template: An instance of troposphere.Template
-    :param name: A name for the subnet
-    :param cidr_block: A CIDR block for the subnet
-    :param availability_zone: An availability zone for the subnet
-    """
-    return template.add_resource(ec2.Subnet(
-        name,
-        VpcId=Ref(vpc),
-        CidrBlock=cidr_block,
-        AvailabilityZone=availability_zone,
-        Tags=Tags(Name=name)
-    ))
-
-
-def create_route(template, name, route_table, cidr_block=None, **attrs):
-    """Creates a route as part of an existing route table
-
-    Arguments
-    :param template: An instance of troposphere.Template
-    :param name: A name for the route
-    :param route_table: An instance of troposphere.ec2.RouteTable
-    :param cidr_block: A CIDR block for the route
-    :param **attrs: Additional arguments for troposphere.ec2.route
-    """
-    cidr_block = cidr_block or ALLOW_ALL_CIDR
-    return template.add_resource(ec2.Route(
-        name,
-        RouteTableId=Ref(route_table),
-        DestinationCidrBlock=cidr_block,
-        **attrs
-    ))
-
-
-def create_security_group(template, name, description, vpc, ingress,
-                          egress, **attrs):
-    """Creates a security group
-
-    Arguments
-    :param template: An instance of troposphere.Template
-    :param name: A name for the security group
-    :param description: A description for the security group
-    :param vpc: An instance of troposphere.ec2.VPC
-    :param ingress: An array of troposphere.ec2.SecurityGroupRules
-    :param egress: An array of troposphere.ec2.SecurityGroupRules
-    :param **attrs: Additional arguments for troposphere.ec2.SecurityGroup
-    """
-    return template.add_resource(ec2.SecurityGroup(
-        name,
-        GroupDescription=description,
-        VpcId=Ref(vpc),
-        SecurityGroupIngress=ingress,
-        SecurityGroupEgress=egress,
-        Tags=Tags(Name=name),
-        **attrs
-    ))
 
 
 def validate_cloudformation_template(template_body):


### PR DESCRIPTION
This changeset adds support for r3 (leader) and i2 (followers) EC2 instance types. In addition, work has been done to streamline the EC2 deployment by:
- Removing unnecessary template helper functions
- Automatic private DNS support
- Waiting for CloudFormation stacks to complete or rollback
- Format and mount ephemeral storage for i2 instances types
- Adding IAM role support to the leader
- Rewriting the README
