### PR TITLE
Add support for parallel stacks

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -11,7 +11,9 @@ $ export AWS_DEFAULT_PROFILE=geotrellis-spark-test
 $ export AWS_PROFILE=geotrellis-spark-test
 $ export AWS_DEFAULT_OUTPUT=text
 $ export AWS_DEFAULT_REGION=us-east-1
+$ export AWS_KEY_NAME=geotrellis-spark-test
 $ export AWS_SNS_TOPIC=arn:aws:sns:us-east-1...
+$ export GEOTRELLIS_SPARK_CLUSTER_NAME=Joker
 ```
 
 Lastly, install the AWS CLI, Boto, and Troposphere:

--- a/deployment/troposphere/leader_template.py
+++ b/deployment/troposphere/leader_template.py
@@ -16,6 +16,11 @@ vpc_param = t.add_parameter(Parameter(
     'VpcId', Type='String', Description='Name of an existing VPC'
 ))
 
+private_hosted_zone_id_param = t.add_parameter(Parameter(
+    'PrivateHostedZoneId', Type='String',
+    Description='Hosted zone ID for private record set'
+))
+
 keyname_param = t.add_parameter(Parameter(
     'KeyName', Type='String', Default='geotrellis-spark-test',
     Description='Name of an existing EC2 key pair'
@@ -104,7 +109,7 @@ mesos_leader = t.add_resource(ec2.Instance(
 #
 mesos_leader_private_dns = t.add_resource(r53.RecordSetGroup(
     'dnsPrivateRecords',
-    HostedZoneName='geotrellis-spark.internal.',
+    HostedZoneId=Ref(private_hosted_zone_id_param),
     RecordSets=[
         r53.RecordSet(
             'dnsZookeeper',


### PR DESCRIPTION
This changeset allows multiple leader/follower clusters to exist within one AWS account. An entirely new VPC is created per cluster, and all of the resources for that cluster are scoped to the VPC.
