### PR TITLE
Remove Mesos public FQDN setup from cloud-config

### DIFF
--- a/deployment/cloud-config/follower.yml
+++ b/deployment/cloud-config/follower.yml
@@ -18,9 +18,6 @@ mounts:
  - [ ephemeral0, "/media/ephemeral0", "ext3", "defaults,nobootwait,discard", "0", "2" ]
  - [ ephemeral1, "/media/ephemeral1", "ext3", "defaults,nobootwait,discard", "0", "2" ]
 
-bootcmd:
- - [ wget, "--quiet", "--output-document", "/etc/mesos-slave/hostname", "http://instance-data.ec2.internal/latest/meta-data/public-hostname" ]
-
 runcmd:
  - [ chown, hdfs, "/media/ephemeral0" ]
  - [ chgrp, hdfs, "/media/ephemeral0" ]

--- a/deployment/cloud-config/leader.yml
+++ b/deployment/cloud-config/leader.yml
@@ -1,4 +1,0 @@
-#cloud-config
-
-bootcmd:
- - [ wget, "--quiet", "--output-document", "/etc/mesos-master/hostname", "http://instance-data.ec2.internal/latest/meta-data/public-hostname" ]

--- a/deployment/troposphere/leader_template.py
+++ b/deployment/troposphere/leader_template.py
@@ -100,7 +100,6 @@ mesos_leader = t.add_resource(ec2.Instance(
             DeleteOnTermination=True,
         )
     ],
-    UserData=Base64(utils.read_file('cloud-config/leader.yml')),
     Tags=Tags(Name='MesosLeader')
 ))
 


### PR DESCRIPTION
This changeset removes the Mesos public FQDN setup from `cloud-config` because all of the other components in the stack use private IPs/private FQDNs. This temporarily breaks interacting with followers via the Mesos UI, but there are plans to remedy that with a VPN into the AWS VPC.
