### PR TITLE
Ensure correct owner and permissions for ephemeral storage

### DIFF
--- a/deployment/cloud-config/follower.yml
+++ b/deployment/cloud-config/follower.yml
@@ -20,7 +20,9 @@ mounts:
 
 runcmd:
  - [ chown, hdfs, "/media/ephemeral0" ]
- - [ chgrp, hdfs, "/media/ephemeral0" ]
+ - [ chgrp, hadoop, "/media/ephemeral0" ]
+ - [ chmod, 770, "/media/ephemeral0" ]
  - [ chown, hdfs, "/media/ephemeral1" ]
- - [ chgrp, hdfs, "/media/ephemeral1" ]
+ - [ chgrp, hadoop, "/media/ephemeral1" ]
+ - [ chmod, 770, "/media/ephemeral1" ]
  - [ service, hadoop-hdfs-datanode, restart ]


### PR DESCRIPTION
This changeset ensures that the ephemeral storage mounts are owned by `hdfs:hadoop`, and that `hadoop` has write access to the mount.

I tested this a few times in isolation. Instance reboots mount the volume again, and its permissions are restored.
