### PR TITLE
Add support for a pptpd VPN into the VPC

### DIFF
--- a/deployment/ansible/group_vars/packer
+++ b/deployment/ansible/group_vars/packer
@@ -9,4 +9,12 @@ hdfs_disks:
   - { device: "/dev/xvdb", mount_point: "/media/ephemeral0" }
   - { device: "/dev/xvdc", mount_point: "/media/ephemeral1" }
 
+pptpd_connections: 100
+pptpd_localip: "10.31.0.1"
+pptpd_remoteip: "10.31.0.234-238,10.31.0.245"
+pptpd_ms_dns:
+  - "10.0.0.2"
+pptpd_users:
+  - { client: "azavea", server: "*", secret: "{{ accumulo_secret }}", address: "*" }
+
 leader_hostnames: "{{ zookeeper_servers[0].ip }} {{ mesos_leader_hostname }} {{ hdfs_namenode_host }} {{ accumulo_leader_host }}"

--- a/deployment/ansible/leader.yml
+++ b/deployment/ansible/leader.yml
@@ -15,6 +15,7 @@
 
   roles:
     - { role: "geotrellis-spark-cluster.common" }
+    - { role: "azavea.pptpd", when: packing }
     - { role: "geotrellis-spark-cluster.hdfs", hdfs_namenode: True }
     - { role: "geotrellis-spark-cluster.mesos", mesos_leader: True }
     - { role: "geotrellis-spark-cluster.accumulo", accumulo_leader: True }

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -8,3 +8,4 @@ azavea.hdfs,0.4.1
 azavea.libgdal-java,0.1.0
 azavea.spark,0.1.1
 azavea.accumulo,0.1.0
+azavea.pptpd,0.2.0

--- a/deployment/troposphere/leader_template.py
+++ b/deployment/troposphere/leader_template.py
@@ -57,7 +57,7 @@ mesos_leader_security_group = t.add_resource(ec2.SecurityGroup(
     SecurityGroupIngress=[
         ec2.SecurityGroupRule(IpProtocol='tcp', CidrIp=Ref(office_cidr_param),
                               FromPort=p, ToPort=p)
-        for p in [22, 4040, 5050, 8080, 50070, 50095]
+        for p in [22, 1723, 4040, 5050, 8080, 50070, 50095]
     ] + [
         ec2.SecurityGroupRule(
             IpProtocol='tcp', CidrIp=utils.VPC_CIDR, FromPort=0, ToPort=65535
@@ -65,12 +65,9 @@ mesos_leader_security_group = t.add_resource(ec2.SecurityGroup(
     ],
     SecurityGroupEgress=[
         ec2.SecurityGroupRule(
-            IpProtocol='tcp', CidrIp=utils.VPC_CIDR, FromPort=0, ToPort=65535
+            IpProtocol='-1', CidrIp=utils.ALLOW_ALL_CIDR,
+            FromPort=0, ToPort=65535
         )
-    ] + [
-        ec2.SecurityGroupRule(IpProtocol='tcp', CidrIp=utils.ALLOW_ALL_CIDR,
-                              FromPort=p, ToPort=p)
-        for p in [80, 443]
     ],
     Tags=Tags(Name='sgMesosLeader')
 ))


### PR DESCRIPTION
This changeset adds support for a `pptpd` VPN into the Amazon VPC via the MesosLeader. Once connected, the private hostnames (MesosFollowers) used by the Mesos UI resolve properly.
