### PR TITLE
Remove Boto deployment dependency

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -5,6 +5,7 @@
 
 build:
 	@find troposphere -name "*.py" | grep -v "utils" | xargs -I{} python {}
+	@find troposphere -name "*.json" | xargs -I{} aws cloudformation validate-template --template-body file://{} > /dev/null
 
 clean:
 	@rm troposphere/*.json

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -8,7 +8,6 @@ The deployment process expects the following environment variables to be overrid
 
 ```bash
 $ export AWS_DEFAULT_PROFILE=geotrellis-spark-test
-$ export AWS_PROFILE=geotrellis-spark-test
 $ export AWS_DEFAULT_OUTPUT=text
 $ export AWS_DEFAULT_REGION=us-east-1
 $ export AWS_KEY_NAME=geotrellis-spark-test
@@ -16,7 +15,7 @@ $ export AWS_SNS_TOPIC=arn:aws:sns:us-east-1...
 $ export GEOTRELLIS_SPARK_CLUSTER_NAME=Joker
 ```
 
-Lastly, install the AWS CLI, Boto, and Troposphere:
+Lastly, install the AWS CLI and Troposphere:
 
 ```bash
 $ cd deployment

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,4 +1,2 @@
 awscli==1.6.10
-boto==2.34.0
-requests==2.4.1
 troposphere==0.6.2

--- a/deployment/troposphere/follower_template.py
+++ b/deployment/troposphere/follower_template.py
@@ -122,11 +122,9 @@ mesos_follower_auto_scaling_group = t.add_resource(asg.AutoScalingGroup(
 ))
 
 if __name__ == '__main__':
-    utils.validate_cloudformation_template(t.to_json())
-
     file_name = __file__.replace('.py', '.json')
 
     with open(file_name, 'w') as f:
         f.write(t.to_json())
 
-    print('Template validated and written to %s' % file_name)
+    print('Template written to %s' % file_name)

--- a/deployment/troposphere/leader_template.py
+++ b/deployment/troposphere/leader_template.py
@@ -142,11 +142,9 @@ mesos_leader_private_dns = t.add_resource(r53.RecordSetGroup(
 ))
 
 if __name__ == '__main__':
-    utils.validate_cloudformation_template(t.to_json())
-
     file_name = __file__.replace('.py', '.json')
 
     with open(file_name, 'w') as f:
         f.write(t.to_json())
 
-    print('Template validated and written to %s' % file_name)
+    print('Template written to %s' % file_name)

--- a/deployment/troposphere/template_utils.py
+++ b/deployment/troposphere/template_utils.py
@@ -1,5 +1,3 @@
-import boto
-
 VPC_CIDR = '10.0.0.0/16'
 ALLOW_ALL_CIDR = '0.0.0.0/0'
 
@@ -22,15 +20,3 @@ def read_file(file_name):
     """
     with open(file_name, 'r') as f:
         return f.read()
-
-
-def validate_cloudformation_template(template_body):
-    """Validates the JSON of a CloudFormation template produced by Troposphere
-
-    Arguments
-    :param template_body: The string representation of CloudFormation template
-                          JSON
-    """
-    c = boto.connect_cloudformation()
-
-    return c.validate_template(template_body=template_body)

--- a/deployment/troposphere/vpc_template.py
+++ b/deployment/troposphere/vpc_template.py
@@ -74,11 +74,9 @@ t.add_output([
 ])
 
 if __name__ == '__main__':
-    utils.validate_cloudformation_template(t.to_json())
-
     file_name = __file__.replace('.py', '.json')
 
     with open(file_name, 'w') as f:
         f.write(t.to_json())
 
-    print('Template validated and written to %s' % file_name)
+    print('Template written to %s' % file_name)


### PR DESCRIPTION
This changeset removes Boto as a deployment dependency. The small amount of work Boto was responsible for (validating CloudFormation scripts) is now being handled by the AWS CLI.
