### PR TITLE
Add support for specifying follower instance types dynamically

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -13,6 +13,7 @@ $ export AWS_DEFAULT_REGION=us-east-1
 $ export AWS_KEY_NAME=geotrellis-spark-test
 $ export AWS_SNS_TOPIC=arn:aws:sns:us-east-1...
 $ export GEOTRELLIS_SPARK_CLUSTER_NAME=Joker
+$ export GEOTRELLIS_SPARK_INSTANCE_TYPE=m3.large
 ```
 
 Lastly, install the AWS CLI and Troposphere:

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -25,6 +25,7 @@ hdfs_namenode_properties:
 hdfs_datanode_properties:
   - { name: "dfs.permissions.superusergroup", value: "hadoop" }
   - { name: "dfs.datanode.data.dir", value: "{{ hdfs_disks | map(attribute='mount_point') | join(',') }}" }
+  - { name: "dfs.datanode.data.dir.perm", value: "770" }
   - { name: "dfs.datanode.synconclose", value: "true" }
 
 accumulo_leader_host: "accumulo-leader.service.geotrellis-spark.internal"

--- a/deployment/ansible/group_vars/packer
+++ b/deployment/ansible/group_vars/packer
@@ -6,7 +6,7 @@ ntp_servers:
   - 3.amazon.pool.ntp.org
 
 hdfs_disks:
-  - { device: "/dev/xvdb", mount_point: "/media/ephemeral0" }
+  - { device: "/dev/sdb", mount_point: "/media/ephemeral0" }
 
 pptpd_connections: 100
 pptpd_localip: "10.31.0.1"

--- a/deployment/ansible/roles/geotrellis-spark-cluster.common/tasks/main.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.common/tasks/main.yml
@@ -17,4 +17,5 @@
 - name: Set system swappiness
   sysctl: name="vm.swappiness"
           value="0"
+          reload=yes
           state=present

--- a/deployment/cloud-config/leader.yml
+++ b/deployment/cloud-config/leader.yml
@@ -1,4 +1,7 @@
 #cloud-config
 
 runcmd:
- - [ sh, -c, "echo \"zookeeper.service.geotrellis-spark.internal $(curl -s http://instance-data.ec2.internal/latest/meta-data/local-ipv4)\" >> /etc/hosts" ]
+ - [ sh, -c, "echo \"$(curl -s http://instance-data.ec2.internal/latest/meta-data/local-ipv4) zookeeper.service.geotrellis-spark.internal\" >> /etc/hosts" ]
+ - [ sh, -c, "echo \"$(curl -s http://instance-data.ec2.internal/latest/meta-data/local-ipv4) mesos-leader.service.geotrellis-spark.internal\" >> /etc/hosts" ]
+ - [ sh, -c, "echo \"$(curl -s http://instance-data.ec2.internal/latest/meta-data/local-ipv4) namenode.service.geotrellis-spark.internal\" >> /etc/hosts" ]
+ - [ sh, -c, "echo \"$(curl -s http://instance-data.ec2.internal/latest/meta-data/local-ipv4) accumulo-leader.service.geotrellis-spark.internal\" >> /etc/hosts" ]

--- a/deployment/cloud-config/packer.yml
+++ b/deployment/cloud-config/packer.yml
@@ -1,12 +1,5 @@
 #cloud-config
 
-fs_setup:
-   - label: ephemeral0,
-     filesystem: ext3
-     extra_opts: [ "-E", "nodiscard" ]
-     device: ephemeral0
-     partition: auto
-
 mounts:
  - [ ephemeral0, null ]
  - [ ephemeral0, "/media/ephemeral0", "ext3", "defaults,nobootwait,discard", "0", "2" ]

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -1,5 +1,7 @@
 {
   "variables": {
+    "aws_access_key": "",
+    "aws_secret_key": "",
     "aws_region": "us-east-1",
     "aws_ssh_username": "ubuntu",
     "aws_ubuntu_ami": ""
@@ -8,9 +10,11 @@
     {
       "name": "mesos-leader",
       "type": "amazon-ebs",
+      "access_key": "{{ user `aws_access_key`}}",
+      "secret_key": "{{ user `aws_secret_key`}}",
       "region": "{{user `aws_region`}}",
       "source_ami": "{{user `aws_ubuntu_ami`}}",
-      "instance_type": "r3.large",
+      "instance_type": "m3.large",
       "ssh_username": "{{user `aws_ssh_username`}}",
       "ami_name": "mesos-leader-{{timestamp}}",
       "run_tags": {
@@ -25,19 +29,17 @@
     {
       "name": "mesos-follower",
       "type": "amazon-ebs",
+      "access_key": "{{ user `aws_access_key`}}",
+      "secret_key": "{{ user `aws_secret_key`}}",
       "region": "{{user `aws_region`}}",
       "source_ami": "{{user `aws_ubuntu_ami`}}",
-      "instance_type": "i2.2xlarge",
+      "instance_type": "m3.large",
       "ssh_username": "{{user `aws_ssh_username`}}",
       "ami_name": "mesos-follower-{{timestamp}}",
       "ami_block_device_mappings": [
         {
-          "device_name": "/dev/xvdb",
+          "device_name": "/dev/sdb",
           "virtual_name": "ephemeral0"
-        },
-        {
-          "device_name": "/dev/xvdc",
-          "virtual_name": "ephemeral1"
         }
       ],
       "user_data_file": "cloud-config/packer.yml",

--- a/deployment/troposphere/follower_template.py
+++ b/deployment/troposphere/follower_template.py
@@ -89,12 +89,36 @@ mesos_follower_launch_config = t.add_resource(asg.LaunchConfiguration(
     AssociatePublicIpAddress=True,
     BlockDeviceMappings=[
         {
-            "DeviceName": "/dev/xvdb",
+            "DeviceName": "/dev/sdb",
             "VirtualName": "ephemeral0"
         },
         {
-            "DeviceName": "/dev/xvdc",
+            "DeviceName": "/dev/sdc",
             "VirtualName": "ephemeral1"
+        },
+        {
+            "DeviceName": "/dev/sdd",
+            "VirtualName": "ephemeral2"
+        },
+        {
+            "DeviceName": "/dev/sde",
+            "VirtualName": "ephemeral3"
+        },
+        {
+            "DeviceName": "/dev/sdf",
+            "VirtualName": "ephemeral4"
+        },
+        {
+            "DeviceName": "/dev/sdg",
+            "VirtualName": "ephemeral5"
+        },
+        {
+            "DeviceName": "/dev/sdh",
+            "VirtualName": "ephemeral6"
+        },
+        {
+            "DeviceName": "/dev/sdi",
+            "VirtualName": "ephemeral7"
         }
     ],
     ImageId=Ref(mesos_follower_ami_param),

--- a/deployment/troposphere/template_utils.py
+++ b/deployment/troposphere/template_utils.py
@@ -8,8 +8,18 @@ EC2_AVAILABILITY_ZONES = [
     'c',
 ]
 EC2_INSTANCE_TYPES = [
+    'c4.8xlarge',
+    'c3.2xlarge',
+    'cc1.4xlarge',
+    'i2.xlarge',
+    'i2.2xlarge',
+    'i2.4xlarge',
+    'i2.8xlarge',
+    'm2.4xlarge',
+    'm3.large',
+    'm3.2xlarge',
     'r3.large',
-    'i2.2xlarge'
+    'r3.2xlarge'
 ]
 
 


### PR DESCRIPTION
This changeset adds support for overriding the follower EC2 instance type via an environment variable at follower stack spin-up.

Resolves https://github.com/hectcastro/vagrant-geotrellis-mesos-spark/pull/20.
