### PR TITLE
Add support for Accumulo 1.6

### DIFF
--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -7,7 +7,7 @@ azavea.marathon,0.2.1
 azavea.hdfs,0.5.0
 azavea.libgdal-java,0.1.0
 azavea.spark,0.3.0
-azavea.accumulo,0.1.0
+azavea.accumulo,0.2.0
 azavea.pptpd,0.2.0
 azavea.graphite,0.4.0
 azavea.grafana,0.1.0

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/tasks/configure_accumulo_leader.yml
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/tasks/configure_accumulo_leader.yml
@@ -13,3 +13,10 @@
         job="/usr/local/bin/accumulo-leader-cron >> /var/log/accumulo-leader-cron.log 2>&1"
         cron_file="accumulo-leader"
         state=present
+
+- name: Configure Accumulo Tracer service
+  template: src=accumulo-tracer.conf.j2
+            dest=/etc/init/accumulo-tracer.conf
+            mode=0644
+  notify:
+    - Restart Accumulo Tracer

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-env.sh.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-env.sh.j2
@@ -20,14 +20,13 @@
 ###
 ### The functional tests require conditional values, so keep this style:
 ###
-### test -z "$JAVA_HOME" && export JAVA_HOME=/usr/local/lib/jdk-1.6.0
+### test -z "$JAVA_HOME" && export JAVA_HOME=/usr/lib/jvm/java
 ###
 ###
 ### Note that the -Xmx -Xms settings below require substantial free memory:
 ### you may want to use smaller values, especially when running everything
 ### on a single machine.
 ###
-
 if [ -z "$HADOOP_HOME" ]
 then
    test -z "$HADOOP_PREFIX"      && export HADOOP_PREFIX=/usr/lib/hadoop
@@ -52,6 +51,12 @@ test -z "$ACCUMULO_GENERAL_OPTS" && export ACCUMULO_GENERAL_OPTS="-XX:+UseConcMa
 test -z "$ACCUMULO_OTHER_OPTS"   && export ACCUMULO_OTHER_OPTS="-Xmx1g -Xms256m"
 # what do when the JVM runs out of heap memory
 export ACCUMULO_KILL_CMD='kill -9 %p'
+
+### Optionally look for hadoop and accumulo native libraries for your
+### platform in additional directories. (Use DYLD_LIBRARY_PATH on Mac OS X.)
+### May not be necessary for Hadoop 2.x or using an RPM that installs to
+### the correct system library directory.
+# export LD_LIBRARY_PATH=${HADOOP_PREFIX}/lib/native/${PLATFORM}:${LD_LIBRARY_PATH}
 
 # Should the monitor bind to all network interfaces -- default: false
 export ACCUMULO_MONITOR_BIND_ALL="true"

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-site.xml.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-site.xml.j2
@@ -52,6 +52,11 @@
   </property>
 
   <property>
+    <name>tserver.memory.maps.native.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
     <name>tserver.cache.data.size</name>
     <value>128M</value>
   </property>
@@ -64,7 +69,7 @@
   <property>
     <name>trace.token.property.password</name>
     <!-- change this to the root user's password, and/or change the user below -->
-    <value>secret</value>
+    <value>{{ accumulo_secret }}</value>
   </property>
 
   <property>
@@ -73,36 +78,40 @@
   </property>
 
   <property>
+    <name>tserver.sort.buffer.size</name>
+    <value>200M</value>
+  </property>
+
+  <property>
+    <name>tserver.walog.max.size</name>
+    <value>1G</value>
+  </property>
+
+  <property>
     <name>general.classpaths</name>
+
     <value>
-      $ACCUMULO_HOME/server/target/classes/,
       $ACCUMULO_HOME/lib/accumulo-server.jar,
-      $ACCUMULO_HOME/core/target/classes/,
       $ACCUMULO_HOME/lib/accumulo-core.jar,
-      $ACCUMULO_HOME/start/target/classes/,
       $ACCUMULO_HOME/lib/accumulo-start.jar,
-      $ACCUMULO_HOME/fate/target/classes/,
       $ACCUMULO_HOME/lib/accumulo-fate.jar,
-      $ACCUMULO_HOME/proxy/target/classes/,
       $ACCUMULO_HOME/lib/accumulo-proxy.jar,
       $ACCUMULO_HOME/lib/[^.].*.jar,
       $ZOOKEEPER_HOME/zookeeper[^.].*.jar,
       $HADOOP_CONF_DIR,
-      $HADOOP_PREFIX/[^.].*.jar,
-      $HADOOP_PREFIX/lib/[^.].*.jar,
-      $HADOOP_PREFIX/share/hadoop/common/.*.jar,
-      $HADOOP_PREFIX/share/hadoop/common/lib/.*.jar,
-      $HADOOP_PREFIX/share/hadoop/hdfs/.*.jar,
-      $HADOOP_PREFIX/share/hadoop/mapreduce/.*.jar,
-      $HADOOP_PREFIX/share/hadoop/yarn/.*.jar,
-      /usr/lib/hadoop/.*.jar,
-      /usr/lib/hadoop/lib/.*.jar,
-      /usr/lib/hadoop-hdfs/.*.jar,
-      /usr/lib/hadoop-mapreduce/.*.jar,
-      /usr/lib/hadoop-yarn/.*.jar,
+      $HADOOP_PREFIX/share/hadoop/common/[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/common/lib/(?!slf4j)[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/hdfs/[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/mapreduce/[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/yarn/[^.].*.jar,
+      $HADOOP_PREFIX/share/hadoop/yarn/lib/jersey.*.jar,
+      /usr/lib/hadoop/[^.].*.jar,
+      /usr/lib/hadoop/lib/[^.].*.jar,
+      /usr/lib/hadoop-hdfs/[^.].*.jar,
+      /usr/lib/hadoop-mapreduce/[^.].*.jar,
+      /usr/lib/hadoop-yarn/[^.].*.jar,
+      /usr/lib/hadoop-yarn/lib/jersey.*.jar,
     </value>
-    <description>Classpaths that accumulo checks for updates and class files.
-      When using the Security Manager, please remove the ".../target/classes/" values.
-    </description>
+    <description>Classpaths that accumulo checks for updates and class files.</description>
   </property>
 </configuration>

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-tracer.conf.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/accumulo-tracer.conf.j2
@@ -1,0 +1,8 @@
+description "accumulo tracer"
+
+start on stopped rc RUNLEVEL=[2345]
+respawn
+setuid accumulo
+chdir /var/lib/accumulo
+
+exec /usr/bin/accumulo tracer --address {{ accumulo_leader_host }} >>/var/log/accumulo/logs/tracer.out 2>>/var/log/accumulo/logs/tracer.err

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/generic_logger.xml.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/generic_logger.xml.j2
@@ -61,10 +61,6 @@
      <appender-ref ref="ASYNC" />
   </logger>
 
-  <logger name="org.apache.accumulo.server.security.Auditor">
-     <level value="WARN"/> <!-- change to INFO for authorization events -->
-  </logger>
-
   <logger name="org.apache.accumulo.core.file.rfile.bcfile">
      <level value="INFO"/>
   </logger>
@@ -73,7 +69,7 @@
      <level value="WARN"/>
   </logger>
 
-  <logger name="com.yahoo.zookeeper">
+  <logger name="org.apache.zookeeper">
      <level value="ERROR"/>
   </logger>
 

--- a/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/log4j.properties.j2
+++ b/deployment/ansible/roles/geotrellis-spark-cluster.accumulo/templates/log4j.properties.j2
@@ -20,8 +20,9 @@ log4j.rootLogger=INFO,A1
 # hide Jetty junk
 log4j.logger.org.mortbay.log=WARN,A1
 
-# hide "Got brand-new compresssor" messages
+# hide "Got brand-new compressor" messages
 log4j.logger.org.apache.hadoop.io.compress=WARN,A1
+log4j.logger.org.apache.accumulo.core.file.rfile.bcfile.Compression=WARN,A1
 
 # hide junk from TestRandomDeletes
 log4j.logger.org.apache.accumulo.test.TestRandomDeletes=WARN,A1


### PR DESCRIPTION
These changes bring over default configuration files from the Accumulo 1.6 distribution.

One additional change had to do with Accumulo's Tracer service. By default, the Tracer sets its address to `0.0.0.0` in Zookeeper, which prevents any clients from connecting to it. The Tracer service definition now explicitly defines a bind address via `--address`.

Still missing `azavea.accumulo` role version bump. Depends on https://github.com/azavea/ansible-accumulo/pull/2.
