### PR TITLE
Add support for Statsite to the cluster leader

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Graphite               | 8081  | [http://localhost:8081](http://localhost:8081)
 ElasticSearch          | 9200  | [http://localhost:9200](http://localhost:9200)
 Grafana                | 8090  | [http://localhost:8090](http://localhost:8090)
 
+**Note**: Statsite (the C port of StatsD) is also running alongside Graphite, but its port number (`8125`) is not forwarded because it is meant for intra-cluster communication.
+
 ### Caching
 
 In order to speed up things up, you may want to consider using installing the [`vagrant-cachier`](https://github.com/fgrehm/vagrant-cachier) plugin:

--- a/deployment/ansible/leader.yml
+++ b/deployment/ansible/leader.yml
@@ -11,6 +11,7 @@
     - { role: "azavea.pptpd", when: packing }
     - { role: "geotrellis-spark-cluster.graphite" } 
     - { role: "geotrellis-spark-cluster.grafana" }
+    - { role: "azavea.statsite" }
     - { role: "geotrellis-spark-cluster.hdfs", hdfs_namenode: True }
     - { role: "geotrellis-spark-cluster.mesos", mesos_leader: True }
     - { role: "geotrellis-spark-cluster.accumulo", accumulo_leader: True }

--- a/deployment/ansible/roles.txt
+++ b/deployment/ansible/roles.txt
@@ -13,3 +13,4 @@ azavea.graphite,0.4.0
 azavea.grafana,0.1.0
 azavea.nginx,0.2.0
 azavea.apache2,0.2.2
+azavea.statsite,0.1.1


### PR DESCRIPTION
This changeset adds support for Statsite to the cluster by spinning up a Statsite server alongside Graphite.

Attempts to resolve #29.

---

From one of the follower virtual machines:

``` bash
$ vagrant@follower01:~$ echo "test.follower01:1|c" | nc -u -w1 33.33.33.10 8125
```

The counter shows up in the Graphite UI:

![image](https://cloud.githubusercontent.com/assets/43639/7459972/bb347784-f26d-11e4-900f-45290e8a34ab.png)
