### PR TITLE
Allow for multiple stacks within one account

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -72,6 +72,7 @@ MesosLeaderInstanceProfile: '<ARN of Mesos Leader Instance Profile (optional -- 
 MesosLeaderInstanceType: '<Mesos Leader Instance Type>'
 Region: '<AWS Region to Launch Stack>'
 StackType: '<Type of Stack to launch (e.g. accumulo)>'
+NameSpace: '<String that identifies user of stack (used to differentiate multiple stacks within a single account)>'
 ```
 
 Multiple configs can be present in the same file, but must be delineated by separate sections using different section headers (`[SECTION]`).

--- a/deployment/cfn/follower.py
+++ b/deployment/cfn/follower.py
@@ -22,6 +22,7 @@ class MesosFollower(utils.GTStackNode):
     """
 
     INPUTS = {
+        'NameSpace': ['global:NameSpace'],
         'AvailabilityZone': ['VPC:AvailabilityZone'],
         'Tags': ['global:Tags'],
         'Region': ['global:Region'],
@@ -37,6 +38,8 @@ class MesosFollower(utils.GTStackNode):
         'MesosFollowerInstanceType': ['global:MesosFollowerInstanceType'],
         'VpcId': ['global:VpcId', 'VPC:VpcId']
     }
+
+    ATTRIBUTES = {'NameSpace': 'NameSpace'}
 
     DEFAULTS = {
         'Tags': {},

--- a/deployment/cfn/leader.py
+++ b/deployment/cfn/leader.py
@@ -14,6 +14,7 @@ class MesosLeader(utils.GTStackNode):
     """Leader stack"""
 
     INPUTS = {
+        'NameSpace': ['global:NameSpace'],
         'Tags': ['global:Tags'],
         'StackType': ['global:StackType'],
         'KeyName': ['global:KeyName'],
@@ -31,6 +32,8 @@ class MesosLeader(utils.GTStackNode):
         'Tags': {},
         'MesosLeaderAMI': None
     }
+
+    ATTRIBUTES = {'NameSpace': 'NameSpace'}
 
     MACHINE_TYPE = 'mesos-leader'
     AMI_INPUT = 'MesosLeaderAMI'

--- a/deployment/cfn/privatehostedzone.py
+++ b/deployment/cfn/privatehostedzone.py
@@ -15,8 +15,11 @@ class R53PrivateHostedZone(CustomActionNode):
     """
     INPUTS = {'VpcId': ['global:VpcId', 'VPC:VpcId'],
               'PrivateHostedZoneName': ['global:PrivateHostedZoneName'],
+              'NameSpace': ['global:NameSpace'],
               'Region': ['global:Region'],
               'StackType': ['global:StackType']}
+
+    ATTRIBUTES = {'NameSpace': 'NameSpace'}
 
     def action(self):
         self.region = self.get_input('Region')

--- a/deployment/cfn/vpc.py
+++ b/deployment/cfn/vpc.py
@@ -16,11 +16,14 @@ class VPC(StackNode):
     INPUTS = {'Tags': ['global:Tags'],
               'Region': ['global:Region'],
               'StackType': ['global:StackType'],
+              'NameSpace': ['global:NameSpace'],
               'IPAccess': ['global:IPAccess']}
 
     DEFAULTS = {
         'Tags': {},
     }
+
+    ATTRIBUTES = {'NameSpace': 'NameSpace'}
 
     def set_up_stack(self):
         super(VPC, self).set_up_stack()

--- a/deployment/geotrellis-cluster.config.example
+++ b/deployment/geotrellis-cluster.config.example
@@ -11,3 +11,4 @@ MesosFollowerSpotPrice: '<Spot Price to use Mesos Follower Instances> (optional)
 PrivateHostedZoneName: '<Name of Private Hosted Zone to use for Private DNS in new VPC>'
 Region: '<AWS Region to Launch Stack>'
 StackType: '<Type of Stack to launch (e.g. accumulo)>'
+NameSpace: '<String that identifies user of stack (used to differentiate multiple stacks within a single account)>'


### PR DESCRIPTION
The suffix generated is deterministic based on tags
and attributes for the stack. This commit adds a user
attribute to stacks and an additional setting to the
config file to allow for multiple stacks to be launched
within a single account.
